### PR TITLE
Deprecate whitelist in favor of new asset_selectors accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ gem "non-digest-assets"
 ```
 
 If you want to generate non-digest assets for only certain files, you can
-configure a list of selected assets like this:
+configure a list of asset selectors like this:
 
 ```ruby
 # config/initializers/non_digest_assets.rb
 
-NonDigestAssets.selected_assets += [/tinymce\/.*/, "image.png"]
+NonDigestAssets.asset_selectors += [/tinymce\/.*/, "image.png"]
 ```
 
 Be sure to give either a regex that will match the right assets or the logical

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Just put it in your Gemfile
 gem "non-digest-assets"
 ```
 
-If you want to whitelist non-digest assets for only certain files, you can
-configure a whitelist like this:
+If you want to generate non-digest assets for only certain files, you can
+configure a list of selected assets like this:
 
 ```ruby
 # config/initializers/non_digest_assets.rb
 
-NonDigestAssets.whitelist += [/tinymce\/.*/, "image.png"]
+NonDigestAssets.selected_assets += [/tinymce\/.*/, "image.png"]
 ```
 
 Be sure to give either a regex that will match the right assets or the logical

--- a/lib/non-digest-assets.rb
+++ b/lib/non-digest-assets.rb
@@ -10,11 +10,11 @@ module NonDigestAssets
 
   class << self
     def filter_assets(asset_list)
-      if whitelist.empty?
+      if selected_assets.empty?
         asset_list
       else
         asset_list.select do |logical_path, _digest_path|
-          whitelist.any? do |item|
+          selected_assets.any? do |item|
             item === logical_path
           end
         end

--- a/lib/non-digest-assets.rb
+++ b/lib/non-digest-assets.rb
@@ -29,7 +29,10 @@ module NonDigestAssets
     alias selected_assets= whitelist=
 
     ActiveSupport::Deprecation
-      .deprecate_methods(self, assets: "use filter_assets instead",
+      .deprecate_methods(self,
+                         assets: "use filter_assets instead",
+                         whitelist: "use selected_assets instead",
+                         "whitelist=": "use selected_assets= instead",
                          deprecator: ActiveSupport::Deprecation.new("2.0.0",
                                                                     "non-digest-assets"))
   end

--- a/lib/non-digest-assets.rb
+++ b/lib/non-digest-assets.rb
@@ -2,6 +2,7 @@
 
 require "sprockets/manifest"
 require "active_support/core_ext/module/attribute_accessors"
+require "active_support/deprecation"
 
 module NonDigestAssets
   mattr_accessor :whitelist
@@ -23,6 +24,11 @@ module NonDigestAssets
     def assets(asset_list)
       filter_assets(asset_list)
     end
+
+    ActiveSupport::Deprecation
+      .deprecate_methods(self, assets: "use filter_assets instead",
+                         deprecator: ActiveSupport::Deprecation.new("2.0.0",
+                                                                    "non-digest-assets"))
   end
 
   module CompileWithNonDigest

--- a/lib/non-digest-assets.rb
+++ b/lib/non-digest-assets.rb
@@ -10,11 +10,11 @@ module NonDigestAssets
 
   class << self
     def filter_assets(asset_list)
-      if selected_assets.empty?
+      if asset_selectors.empty?
         asset_list
       else
         asset_list.select do |logical_path, _digest_path|
-          selected_assets.any? do |item|
+          asset_selectors.any? do |item|
             item === logical_path
           end
         end
@@ -25,14 +25,14 @@ module NonDigestAssets
       filter_assets(asset_list)
     end
 
-    alias selected_assets whitelist
-    alias selected_assets= whitelist=
+    alias asset_selectors whitelist
+    alias asset_selectors= whitelist=
 
     ActiveSupport::Deprecation
       .deprecate_methods(self,
                          assets: "use filter_assets instead",
-                         whitelist: "use selected_assets instead",
-                         "whitelist=": "use selected_assets= instead",
+                         whitelist: "use asset_selectors instead",
+                         "whitelist=": "use asset_selectors= instead",
                          deprecator: ActiveSupport::Deprecation.new("2.0.0",
                                                                     "non-digest-assets"))
   end

--- a/lib/non-digest-assets.rb
+++ b/lib/non-digest-assets.rb
@@ -9,17 +9,13 @@ module NonDigestAssets
 
   class << self
     def assets(assets)
-      return assets if whitelist.empty?
-
-      whitelisted_assets(assets)
-    end
-
-    private
-
-    def whitelisted_assets(assets)
-      assets.select do |logical_path, _digest_path|
-        whitelist.any? do |item|
-          item === logical_path
+      if whitelist.empty?
+        assets
+      else
+        assets.select do |logical_path, _digest_path|
+          whitelist.any? do |item|
+            item === logical_path
+          end
         end
       end
     end

--- a/lib/non-digest-assets.rb
+++ b/lib/non-digest-assets.rb
@@ -25,6 +25,9 @@ module NonDigestAssets
       filter_assets(asset_list)
     end
 
+    alias selected_assets whitelist
+    alias selected_assets= whitelist=
+
     ActiveSupport::Deprecation
       .deprecate_methods(self, assets: "use filter_assets instead",
                          deprecator: ActiveSupport::Deprecation.new("2.0.0",

--- a/lib/non-digest-assets.rb
+++ b/lib/non-digest-assets.rb
@@ -8,16 +8,20 @@ module NonDigestAssets
   @@whitelist = []
 
   class << self
-    def assets(assets)
+    def filter_assets(asset_list)
       if whitelist.empty?
-        assets
+        asset_list
       else
-        assets.select do |logical_path, _digest_path|
+        asset_list.select do |logical_path, _digest_path|
           whitelist.any? do |item|
             item === logical_path
           end
         end
       end
+    end
+
+    def assets(asset_list)
+      filter_assets(asset_list)
     end
   end
 
@@ -32,7 +36,7 @@ module NonDigestAssets
 
     def compile(*args)
       paths = super
-      NonDigestAssets.assets(assets).each do |(logical_path, digest_path)|
+      NonDigestAssets.filter_assets(assets).each do |(logical_path, digest_path)|
         full_digest_path = File.join dir, digest_path
         full_digest_gz_path = "#{full_digest_path}.gz"
         full_non_digest_path = File.join dir, logical_path

--- a/spec/unit/non_digest_assets/compile_with_non_digest_spec.rb
+++ b/spec/unit/non_digest_assets/compile_with_non_digest_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe NonDigestAssets::CompileWithNonDigest, type: :aruba do
   end
 
   before do
-    NonDigestAssets.selected_assets = []
+    NonDigestAssets.asset_selectors = []
   end
 
   describe "#compile" do
@@ -63,7 +63,7 @@ RSpec.describe NonDigestAssets::CompileWithNonDigest, type: :aruba do
       end
 
       it "does not copy files for non-selected assets" do
-        NonDigestAssets.selected_assets = ["bar.css"]
+        NonDigestAssets.asset_selectors = ["bar.css"]
         sprockets.compile
         aggregate_failures do
           expect("foo.css").not_to be_an_existing_file
@@ -109,7 +109,7 @@ RSpec.describe NonDigestAssets::CompileWithNonDigest, type: :aruba do
       end
 
       it "does not copy files for non-selected assets" do
-        NonDigestAssets.selected_assets = ["bar.css"]
+        NonDigestAssets.asset_selectors = ["bar.css"]
         sprockets.compile
         aggregate_failures do
           expect("foo.css").not_to be_an_existing_file

--- a/spec/unit/non_digest_assets/compile_with_non_digest_spec.rb
+++ b/spec/unit/non_digest_assets/compile_with_non_digest_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe NonDigestAssets::CompileWithNonDigest, type: :aruba do
   end
 
   before do
-    NonDigestAssets.whitelist = []
+    NonDigestAssets.selected_assets = []
   end
 
   describe "#compile" do
@@ -62,8 +62,8 @@ RSpec.describe NonDigestAssets::CompileWithNonDigest, type: :aruba do
         end
       end
 
-      it "does not copy files for non-whitelisted assets" do
-        NonDigestAssets.whitelist = ["bar.css"]
+      it "does not copy files for non-selected assets" do
+        NonDigestAssets.selected_assets = ["bar.css"]
         sprockets.compile
         aggregate_failures do
           expect("foo.css").not_to be_an_existing_file
@@ -108,8 +108,8 @@ RSpec.describe NonDigestAssets::CompileWithNonDigest, type: :aruba do
         end
       end
 
-      it "does not copy files for non-whitelisted assets" do
-        NonDigestAssets.whitelist = ["bar.css"]
+      it "does not copy files for non-selected assets" do
+        NonDigestAssets.selected_assets = ["bar.css"]
         sprockets.compile
         aggregate_failures do
           expect("foo.css").not_to be_an_existing_file

--- a/spec/unit/non_digest_assets_spec.rb
+++ b/spec/unit/non_digest_assets_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe NonDigestAssets do
       described_class.selected_assets = %w(bar baz)
       expect(described_class.filter_assets(%w(foo bar))).to eq ["bar"]
     end
+
+    it "allows filtering using a regex" do
+      described_class.selected_assets = [/ba/]
+      expect(described_class.filter_assets(%w(foo bar ababa))).to eq %w(bar ababa)
+    end
   end
 
   describe ".assets (deprecated)" do

--- a/spec/unit/non_digest_assets_spec.rb
+++ b/spec/unit/non_digest_assets_spec.rb
@@ -19,25 +19,25 @@ RSpec.describe NonDigestAssets do
   end
 
   describe ".filter_assets" do
-    it "returns its arguments if there are no whitelisted assets" do
-      described_class.whitelist = []
+    it "returns its arguments if there are no selected assets" do
+      described_class.selected_assets = []
       expect(described_class.filter_assets(%w(foo bar))).to eq %w(foo bar)
     end
 
-    it "returns only whitelisted parts of arguments if there are whitelisted assets" do
-      described_class.whitelist = %w(bar baz)
+    it "returns only selected parts of arguments if there are selected assets" do
+      described_class.selected_assets = %w(bar baz)
       expect(described_class.filter_assets(%w(foo bar))).to eq ["bar"]
     end
   end
 
   describe ".assets (deprecated)" do
-    it "returns its arguments if there are no whitelisted assets" do
-      described_class.whitelist = []
+    it "returns its arguments if there are no selected assets" do
+      described_class.selected_assets = []
       expect(described_class.assets(%w(foo bar))).to eq %w(foo bar)
     end
 
-    it "returns only whitelisted parts of arguments if there are whitelisted assets" do
-      described_class.whitelist = %w(bar baz)
+    it "returns only selected parts of arguments if there are selected assets" do
+      described_class.selected_assets = %w(bar baz)
       expect(described_class.assets(%w(foo bar))).to eq ["bar"]
     end
   end

--- a/spec/unit/non_digest_assets_spec.rb
+++ b/spec/unit/non_digest_assets_spec.rb
@@ -4,6 +4,20 @@ require "spec_helper"
 require "non-digest-assets"
 
 RSpec.describe NonDigestAssets do
+  describe ".selected_assets" do
+    it "is an alternative reader for .whitelist" do
+      described_class.whitelist = %w(baz qux)
+      expect(described_class.selected_assets).to eq %w(baz qux)
+    end
+  end
+
+  describe ".selected_assets=" do
+    it "is an alternative setter for .whitelist" do
+      described_class.selected_assets = %w(qux quuz)
+      expect(described_class.whitelist).to eq %w(qux quuz)
+    end
+  end
+
   describe ".filter_assets" do
     it "returns its arguments if there are no whitelisted assets" do
       described_class.whitelist = []

--- a/spec/unit/non_digest_assets_spec.rb
+++ b/spec/unit/non_digest_assets_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe NonDigestAssets do
     end
   end
 
-  describe ".assets" do
+  describe ".assets (deprecated)" do
     it "returns its arguments if there are no whitelisted assets" do
       described_class.whitelist = []
       expect(described_class.assets(%w(foo bar))).to eq %w(foo bar)

--- a/spec/unit/non_digest_assets_spec.rb
+++ b/spec/unit/non_digest_assets_spec.rb
@@ -4,6 +4,18 @@ require "spec_helper"
 require "non-digest-assets"
 
 RSpec.describe NonDigestAssets do
+  describe ".filter_assets" do
+    it "returns its arguments if there are no whitelisted assets" do
+      described_class.whitelist = []
+      expect(described_class.filter_assets(%w(foo bar))).to eq %w(foo bar)
+    end
+
+    it "returns only whitelisted parts of arguments if there are whitelisted assets" do
+      described_class.whitelist = %w(bar baz)
+      expect(described_class.filter_assets(%w(foo bar))).to eq ["bar"]
+    end
+  end
+
   describe ".assets" do
     it "returns its arguments if there are no whitelisted assets" do
       described_class.whitelist = []

--- a/spec/unit/non_digest_assets_spec.rb
+++ b/spec/unit/non_digest_assets_spec.rb
@@ -4,45 +4,45 @@ require "spec_helper"
 require "non-digest-assets"
 
 RSpec.describe NonDigestAssets do
-  describe ".selected_assets" do
+  describe ".asset_selectors" do
     it "is an alternative reader for .whitelist" do
       described_class.whitelist = %w(baz qux)
-      expect(described_class.selected_assets).to eq %w(baz qux)
+      expect(described_class.asset_selectors).to eq %w(baz qux)
     end
   end
 
-  describe ".selected_assets=" do
+  describe ".asset_selectors=" do
     it "is an alternative setter for .whitelist" do
-      described_class.selected_assets = %w(qux quuz)
+      described_class.asset_selectors = %w(qux quuz)
       expect(described_class.whitelist).to eq %w(qux quuz)
     end
   end
 
   describe ".filter_assets" do
     it "returns its arguments if there are no selected assets" do
-      described_class.selected_assets = []
+      described_class.asset_selectors = []
       expect(described_class.filter_assets(%w(foo bar))).to eq %w(foo bar)
     end
 
     it "returns only selected parts of arguments if there are selected assets" do
-      described_class.selected_assets = %w(bar baz)
+      described_class.asset_selectors = %w(bar baz)
       expect(described_class.filter_assets(%w(foo bar))).to eq ["bar"]
     end
 
     it "allows filtering using a regex" do
-      described_class.selected_assets = [/ba/]
+      described_class.asset_selectors = [/ba/]
       expect(described_class.filter_assets(%w(foo bar ababa))).to eq %w(bar ababa)
     end
   end
 
   describe ".assets (deprecated)" do
     it "returns its arguments if there are no selected assets" do
-      described_class.selected_assets = []
+      described_class.asset_selectors = []
       expect(described_class.assets(%w(foo bar))).to eq %w(foo bar)
     end
 
     it "returns only selected parts of arguments if there are selected assets" do
-      described_class.selected_assets = %w(bar baz)
+      described_class.asset_selectors = %w(bar baz)
       expect(described_class.assets(%w(foo bar))).to eq ["bar"]
     end
   end


### PR DESCRIPTION
This is part of #41.

This provides `asset_selectors` as an alternative for `whitelist`, deprecating the latter. It also deprecates `assets` in favor of `filter_assets`, although `assets` is probably rarely used directly.