### PR TITLE
Remove deprecated methods `whitelist`, `whitelist=`, and `assets`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Remove deprecated methods `whitelist`, `whitelist=`, and `assets`
+
 ## [1.2.0](https://github.com/mvz/non-digest-assets/tree/v1.2.0)
 
 ### Summary

--- a/lib/non-digest-assets.rb
+++ b/lib/non-digest-assets.rb
@@ -2,11 +2,10 @@
 
 require "sprockets/manifest"
 require "active_support/core_ext/module/attribute_accessors"
-require "active_support/deprecation"
 
 module NonDigestAssets
-  mattr_accessor :whitelist
-  @@whitelist = []
+  mattr_accessor :asset_selectors
+  @@asset_selectors = []
 
   class << self
     def filter_assets(asset_list)
@@ -30,21 +29,6 @@ module NonDigestAssets
       FileUtils.rm_f to
       FileUtils.copy_file from, to, :preserve_attributes
     end
-
-    def assets(asset_list)
-      filter_assets(asset_list)
-    end
-
-    alias_method :asset_selectors, :whitelist
-    alias_method :asset_selectors=, :whitelist=
-
-    ActiveSupport::Deprecation.deprecate_methods(
-      self,
-      assets: "use filter_assets instead",
-      whitelist: "use asset_selectors instead",
-      "whitelist=": "use asset_selectors= instead",
-      deprecator: ActiveSupport::Deprecation.new("2.0.0", "non-digest-assets")
-    )
   end
 
   module CompileWithNonDigest

--- a/spec/unit/non_digest_assets_spec.rb
+++ b/spec/unit/non_digest_assets_spec.rb
@@ -5,16 +5,9 @@ require "non-digest-assets"
 
 RSpec.describe NonDigestAssets do
   describe ".asset_selectors" do
-    it "is an alternative reader for .whitelist" do
-      described_class.whitelist = %w[baz qux]
+    it "returns what was set with .asset_selectors=" do
+      described_class.asset_selectors = %w[baz qux]
       expect(described_class.asset_selectors).to eq %w[baz qux]
-    end
-  end
-
-  describe ".asset_selectors=" do
-    it "is an alternative setter for .whitelist" do
-      described_class.asset_selectors = %w[qux quuz]
-      expect(described_class.whitelist).to eq %w[qux quuz]
     end
   end
 
@@ -32,18 +25,6 @@ RSpec.describe NonDigestAssets do
     it "allows filtering using a regex" do
       described_class.asset_selectors = [/ba/]
       expect(described_class.filter_assets(%w[foo bar ababa])).to eq %w[bar ababa]
-    end
-  end
-
-  describe ".assets (deprecated)" do
-    it "returns its arguments if there are no selected assets" do
-      described_class.asset_selectors = []
-      expect(described_class.assets(%w[foo bar])).to eq %w[foo bar]
-    end
-
-    it "returns only selected parts of arguments if there are selected assets" do
-      described_class.asset_selectors = %w[bar baz]
-      expect(described_class.assets(%w[foo bar])).to eq ["bar"]
     end
   end
 end


### PR DESCRIPTION
These methods were deprecated earlier. Remove then in preparation for the next major release. This is a breaking change.

Part of #41.
