### PR TITLE
Finalize Rails 7 support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,16 +19,12 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.6, 2.7]
-        appraisal: [rails_5_2, rails_6_0, rails_6_1]
-        include:
-          - ruby: 2.7
-            appraisal: rails_7_0
+        ruby: [2.6, 2.7, "3.0"]
+        appraisal: [rails_5_2, rails_6_0, rails_6_1, rails_7_0]
+        exclude:
           - ruby: "3.0"
-            appraisal: rails_6_0
-          - ruby: "3.0"
-            appraisal: rails_6_1
-          - ruby: "3.0"
+            appraisal: rails_5_2
+          - ruby: 2.6
             appraisal: rails_7_0
 
     env:

--- a/Appraisals
+++ b/Appraisals
@@ -16,6 +16,6 @@ appraise "rails_6_1" do
 end
 
 appraise "rails_7_0" do
-  gem "rails", "~> 7.0.0.alpha2"
+  gem "rails", "~> 7.0.0"
   gem "sprockets", "~> 4.0"
 end

--- a/Appraisals
+++ b/Appraisals
@@ -17,5 +17,6 @@ end
 
 appraise "rails_7_0" do
   gem "rails", "~> 7.0.0"
+  gem "sprockets-rails", "~> 3.0"
   gem "sprockets", "~> 4.0"
 end

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -6,5 +6,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 7.0.0"
 gem "sprockets", "~> 4.0"
+gem "sprockets-rails", "~> 3.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -4,7 +4,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 7.0.0.alpha2"
+gem "rails", "~> 7.0.0"
 gem "sprockets", "~> 4.0"
 
 gemspec path: "../"

--- a/non-digest-assets.gemspec
+++ b/non-digest-assets.gemspec
@@ -22,13 +22,13 @@ Gem::Specification.new do |spec|
 
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.add_dependency "activesupport", ">= 5.2"
+  spec.add_dependency "activesupport", [">= 5.2", "< 7.1"]
   spec.add_dependency "sprockets", [">= 2.0", "< 5.0"]
 
   spec.add_development_dependency "appraisal", "~> 2.3"
   spec.add_development_dependency "aruba", "~> 2.0"
   spec.add_development_dependency "pry", "~> 0.14.0"
-  spec.add_development_dependency "rails", ">= 5.0"
+  spec.add_development_dependency "rails", [">= 5.2", "< 7.1"]
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.10"
   spec.add_development_dependency "rubocop", "~> 1.23.0"


### PR DESCRIPTION
- Update Rails 7.0 appraisal for Rails 7.0 release 
- Tighten Rails-related dependencies again
- Simplify GitHub action strategy matrix
- Make the `assets:precompile` task available when testing with Rails 7.0