### PR TITLE
Support Ruby 3.0 and up

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
         appraisal: [rails_6_0, rails_6_1, rails_7_0, rails_7_1]
 
     env:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/non-digest-assets.gemspec
+++ b/non-digest-assets.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
   spec.require_path = "lib"
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["rubygems_mfa_required"] = "true"
 


### PR DESCRIPTION
- Drop support for Ruby 2.7
- Build with Rubies 3.0 through 3.3 in CI
