### PR TITLE
Support Ruby 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4"]
         appraisal:
           - rails_6_0
           - rails_6_1

--- a/non-digest-assets.gemspec
+++ b/non-digest-assets.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.add_dependency "activesupport", ">= 6.0", "< 8.1"
+  spec.add_dependency "mutex_m", "~> 0.3.0"
   spec.add_dependency "sprockets", "~> 4.0"
 
   spec.add_development_dependency "appraisal", "~> 2.3"


### PR DESCRIPTION
- Add Ruby 3.4 to the GitHub Actions matrix
- Add dependency on `mutex_m` gem which is no longer part of the default gems shipped with Ruby starting from Ruby 3.4.0.
