### PR TITLE
Test older rails versions with compatible concurrent-ruby version

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -10,16 +10,19 @@ Customize.new heading: <<~HEADING.chomp
 HEADING
 
 appraise "rails_6_0" do
+  gem "concurrent-ruby", "1.3.4"
   gem "rails", "~> 6.0.0"
   gem "sprockets", "~> 4.0"
 end
 
 appraise "rails_6_1" do
+  gem "concurrent-ruby", "1.3.4"
   gem "rails", "~> 6.1.0"
   gem "sprockets", "~> 4.0"
 end
 
 appraise "rails_7_0" do
+  gem "concurrent-ruby", "1.3.4"
   gem "rails", "~> 7.0.0"
   gem "sprockets", "~> 4.0"
   gem "sprockets-rails", "~> 3.0"

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -4,6 +4,7 @@
 
 source "https://rubygems.org"
 
+gem "concurrent-ruby", "1.3.4"
 gem "rails", "~> 6.0.0"
 gem "sprockets", "~> 4.0"
 

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -4,6 +4,7 @@
 
 source "https://rubygems.org"
 
+gem "concurrent-ruby", "1.3.4"
 gem "rails", "~> 6.1.0"
 gem "sprockets", "~> 4.0"
 

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -4,6 +4,7 @@
 
 source "https://rubygems.org"
 
+gem "concurrent-ruby", "1.3.4"
 gem "rails", "~> 7.0.0"
 gem "sprockets", "~> 4.0"
 gem "sprockets-rails", "~> 3.0"


### PR DESCRIPTION
Version 1.3.5 of concurrent-ruby stopped requiring 'logger', leading to build failures for Rails. Rails 7.0 and below will not be updated with a fix, so we need to pin concurrent-ruby to the last compatible version.
