### PR TITLE
In CI, limit Ruby/Rails combinations to the ones that were active together

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,27 +18,52 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4"]
-        appraisal:
-          - rails_6_0
-          - rails_6_1
-          - rails_7_0
-          - rails_7_1
-          - rails_7_2
-          - rails_8_0
-          - rails_8_1
-        exclude:
-          - ruby: "3.0"
-            appraisal: rails_7_2
-          - ruby: "3.0"
-            appraisal: rails_8_0
-          - ruby: "3.1"
-            appraisal: rails_8_0
-          - ruby: "3.0"
-            appraisal: rails_8_1
-          - ruby: "3.1"
-            appraisal: rails_8_1
         include:
+          - ruby: "3.0"
+            appraisal: rails_6_0
+          - ruby: "3.0"
+            appraisal: rails_6_1
+          - ruby: "3.0"
+            appraisal: rails_7_0
+          - ruby: "3.0"
+            appraisal: rails_7_1
+
+          - ruby: "3.1"
+            appraisal: rails_7_0
+          - ruby: "3.1"
+            appraisal: rails_7_1
+          - ruby: "3.1"
+            appraisal: rails_7_2
+          - ruby: "3.1"
+            appraisal: rails_8_0
+
+          - ruby: "3.2"
+            appraisal: rails_7_0
+          - ruby: "3.2"
+            appraisal: rails_7_1
+          - ruby: "3.2"
+            appraisal: rails_7_2
+          - ruby: "3.2"
+            appraisal: rails_8_0
+          - ruby: "3.2"
+            appraisal: rails_8_1
+
+          - ruby: "3.3"
+            appraisal: rails_7_1
+          - ruby: "3.3"
+            appraisal: rails_7_2
+          - ruby: "3.3"
+            appraisal: rails_8_0
+          - ruby: "3.3"
+            appraisal: rails_8_1
+
+          - ruby: "3.4"
+            appraisal: rails_7_2
+          - ruby: "3.4"
+            appraisal: rails_8_0
+          - ruby: "3.4"
+            appraisal: rails_8_1
+
           - ruby: "4.0"
             appraisal: rails_8_0
           - ruby: "4.0"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,6 +19,11 @@ jobs:
     strategy:
       matrix:
         include:
+          # Only combinations where both versions were supported at the same
+          # time are included here. For Rails, support is assumed to end when
+          # active support ends; for Ruby, support is assumed to end at
+          # end-of-life.
+
           - ruby: "3.0"
             appraisal: rails_6_0
           - ruby: "3.0"
@@ -34,8 +39,9 @@ jobs:
             appraisal: rails_7_1
           - ruby: "3.1"
             appraisal: rails_7_2
-          - ruby: "3.1"
-            appraisal: rails_8_0
+          # Rails 8.0 explictly depends on Ruby 3.2 or higher, so the combination
+          # of Rails 8.0 and Ruby 3.1 is excluded even though Rails 8.0 was
+          # released before Ruby 3.1 was EOL.
 
           - ruby: "3.2"
             appraisal: rails_7_0


### PR DESCRIPTION
We will assume that users will use other combinations. For example, it makes no sense to upgrade to Ruby 3.1 while still on Rails 6.0, since Rails 6.0 was already out of active support when Ruby 3.1 was released.
